### PR TITLE
Add robots metadata route

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import { MetadataRoute } from 'next';
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://example.com';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: new URL('/sitemap.xml', siteUrl).toString(),
+  };
+}


### PR DESCRIPTION
## Summary
- add a Next.js metadata route at `app/robots.ts` that exposes a wildcard crawl rule and sitemap URL built from the public site URL

## Testing
- NEXT_PUBLIC_SITE_URL=https://qiu.dev npm run dev
- curl -s http://localhost:3000/robots.txt


------
https://chatgpt.com/codex/tasks/task_e_68daa87d808083299a2d2e958084dfb7