### PR TITLE
Add sitemap metadata route and link in robots

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+export const BASE_URL = "https://qiuautomations.com" as const;
+
+export default function robots(): MetadataRoute.Robots {
+  const origin = new URL(BASE_URL);
+
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: new URL("/sitemap.xml", origin).toString(),
+    host: origin.origin,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from "next";
+import { BASE_URL } from "./robots";
+
+type ChangeFrequency = MetadataRoute.Sitemap[number]["changeFrequency"];
+
+const lastModified = new Date();
+
+const sections: Array<{ path: string; changeFrequency: ChangeFrequency }> = [
+  { path: "/", changeFrequency: "weekly" },
+  { path: "/#beneficios", changeFrequency: "monthly" },
+  { path: "/#servicios", changeFrequency: "monthly" },
+  { path: "/#proceso", changeFrequency: "monthly" },
+  { path: "/#contacto", changeFrequency: "monthly" },
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return sections.map(({ path, changeFrequency }) => ({
+    url: new URL(path, BASE_URL).toString(),
+    lastModified,
+    changeFrequency,
+  }));
+}


### PR DESCRIPTION
## Summary
- add a sitemap metadata route that lists the main landing page sections with last modified metadata
- share the base URL between metadata routes and expose the sitemap link from the robots file
- update the robots metadata to ensure search crawlers can find the sitemap

## Testing
- npm run build *(fails: unable to download remote fonts in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68daa9c82ebc8329be627d44a349467f