### PR TITLE
Add tracking query parameter after contact form submission

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,6 +27,11 @@ export default function Home() {
 
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       setStatus("ok");
+      if (typeof window !== "undefined") {
+        const url = new URL(window.location.href);
+        url.searchParams.set("form_submitted", "1");
+        window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
+      }
       form.reset();
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- add a client-side history update that appends a `form_submitted` flag to the URL when the contact form submits successfully

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfdd02fb388329a47fc0322da43381